### PR TITLE
Release 1.0.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,10 @@ cache:
 before_script:
   - bundle -v
   - rm Gemfile.lock || true
-  - gem update --system $RUBYGEMS_VERSION
+  - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
+  - "# Set `rubygems_version` in the .sync.yml to set a value"
+  - "# Ignore exit code of SIGPIPE'd yes to not fail with shell's pipefail set"
+  - '[ -z "$RUBYGEMS_VERSION" ] || (yes || true) | gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
   - bundle install --without system_tests --path vendor/bundle --jobs $(nproc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ cache: bundler
 before_install:
   - bundle -v
   - rm -f Gemfile.lock
-  - gem update --system $RUBYGEMS_VERSION
+  - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
+  - "# See https://github.com/puppetlabs/pdk-templates/commit/705154d5c437796b821691b707156e1b056d244f for an example of how this was used"
+  - "# Ignore exit code of SIGPIPE'd yes to not fail with shell's pipefail set"
+  - '[ -z "$RUBYGEMS_VERSION" ] || (yes || true) | gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,30 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.0
+
+### Features
+
+- Ability to set string values to the hostcustomproperties.conf and hostautotag.conf of the OneAgent config to add tags and metadata to a host entity.
+- Ability to override the automatically detected hostname by setting the values of the hostname.conf file and restarting the Dynatrace OneAgent service.
+
+### Bugfixes
+
+- Remove debug message for whenever reboot parameter was set to false
+
+### Known Issues
+
+TBD
+
 ## Release 0.5.0
 
-**Features**
+### Features
 
-Ability to download specific version
+- Ability to download specific version
+- Module will automatically detect OS and download required installer
+- Module will automatically detect OS and will run the installer package required
+- Add AIX support
+- Add support for OneAgent Install Params
+- Implement Archive module for OneAgent installer downloads
+- Reboot functionality included
+- Module built and validated with PDK
 
-Module will automatically detect OS and download required installer
+### Bugfixes
 
-Module will automatically detect OS and will run the installer package required
+- Fix OneAgent download issue
+- Fix module directory issue
 
-Add AIX support
+### Known Issues
 
-Add support for OneAgent Install Params
-
-Implement Archive module for OneAgent installer downloads
-
-Reboot functionality included
-
-Module built and validated with PDK
-
-**Bugfixes**
-
-Fix OneAgent download issue
-
-Fix module directory issue
-
-**Known Issues**
+TBD

--- a/Gemfile
+++ b/Gemfile
@@ -24,10 +24,10 @@ group :development do
   gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.3', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.3',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.4', require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/README.md
+++ b/README.md
@@ -2,47 +2,58 @@
 
 ## Description
 
-This module installs the OneAgent on Linux, Windows and AIX Operating Systems
+This module deploys the Dynatrace OneAgent on Linux, Windows and AIX Operating Systems with different available configurations and ensures the OneAgent service maintains a running state. It provides the resource types to interact with the various OneAgent configuration files.
 
-## Requirements
+## Setup
 
-Requires [puppet/archive](https://forge.puppet.com/puppet/archive)
+### Setup requirements
 
-Requires [puppet-labs/reboot](https://forge.puppet.com/puppetlabs/reboot) for Windows reboots
+This module requires [puppet/archive] as well as [puppet-labs/reboot] for Windows restarts.
 
-## Installation
+To begin using this module, use the Puppet Module Tool (PMT) from the command line to install this module:
 
-Available from GitHub (via cloning) or via Puppet forge [dynatrace/dynatraceoneagent](https://forge.puppet.com/dynatrace/dynatraceoneagent)
+```bash
+puppet module install dynatrace-dynatraceoneagent
+```
 
-Refer to the customize OneAgent installation documentation on [Dynatrace Supported Operating Systems](https://www.dynatrace.com/support/help/technology-support/operating-systems/)
+You will then need to supply the dynatraceoneagent class with two critical pieces of information.
 
-This module uses the Dynatrace deployment API for downloading the installer for each supported OS. See [Deployment API](https://www.dynatrace.com/support/help/extend-dynatrace/dynatrace-api/environment-api/deployment/)
+- The tenant URL: **Managed** `https://{your-domain}/e/{your-environment-id}` |  **SaaS** `https://{your-environment-id}.live.dynatrace.com`
+- The PaaS token of your environment for downloading the OneAgent installer
+
+Refer to the customize OneAgent installation documentation on [Dynatrace Supported Operating Systems]
+This module uses the Dynatrace deployment API for downloading the installer for each supported OS. See [Deployment API]
 
 ## Usage
 
-Look at init.pp to see what can be configured.
-
 Default OneAgent install parameters defined in params.pp as a hash map: INFRA_ONLY=0, APP_LOG_CONTENT_ACCESS=1
 
-Sample latest OneAgent version installation using a SAAS tenant
+Most basic OneAgent installation using a SAAS tenant:
 
+```bash
     class { 'dynatraceoneagent':
         tenant_url  => 'https://{your-environment-id}.live.dynatrace.com',
         paas_token  => '{your-paas-token}',
     }
+```
 
-Sample OneAgent installation using a managed tenant with a specific version. The required version of the OneAgent must be in 1.155.275.20181112-084458 format. See [Deployment API - GET available versions of OneAgent](https://www.dynatrace.com/support/help/extend-dynatrace/dynatrace-api/environment-api/deployment/oneagent/get-available-versions/)
+### OneAgent installation using a managed tenant with a specific version
 
+The required version of the OneAgent must be in 1.155.275.20181112-084458 format. See [Deployment API - GET available versions of OneAgent]
+
+```bash
     class { 'dynatraceoneagent':
         tenant_url  => 'https://{your-domain}/e/{your-environment-id}',
         paas_token  => '{your-paas-token}',
         version     => '1.181.63.20191105-161318',
     }
+```
 
-## Advanced configuration
+### Advanced configuration
 
 Download OneAgent installer to a custom directory with additional OneAgent install parameters and reboot server after install should be defined as follows (will override default install params):
 
+```bash
     class { 'dynatraceoneagent':
         tenant_url            => 'https://{your-environment-id}.live.dynatrace.com',
         paas_token            => '{your-paas-token}',
@@ -56,54 +67,44 @@ Download OneAgent installer to a custom directory with additional OneAgent insta
             'INSTALL_PATH'           => 'C:\Test Directory',
         }
     }
+```
 
 For Windows, because download_dir is a string variable, 2 backslashes are required
+Since the OneAgent install parameter INSTALL_PATH can be defined within a hash map, no escaping is needed for Windows file paths
+For further information on how to handle file paths on Windows, visit [Handling file paths on Windows]
 
-Since the oneagent install parameter INSTALL_PATH can be defined within a hash map, no escaping is needed for Windows file paths
+### Setting tags, metadata and custom hostname
 
-For further information on how to handle file paths on Windows, visit [Handling file paths on Windows](https://puppet.com/docs/puppet/4.10/lang_windows_file_paths.html)
+Configure values to automatically add tags and metadata to a host and override an automatically detected host name, the values should contain a list of strings or key/value pairs. Spaces are used to separate tag and metadata values.
 
-## Parameters
+```bash
+    class { 'dynatraceoneagent':
+        tenant_url       => 'https://{your-domain}/e/{your-environment-id}',
+        paas_token       => '{your-paas-token}',
+        host_tags        => 'TestHost Gdansk role=fallback',
+        host_metadata    => 'Environment=Prod Organization=D1P Owner=john.doe@dynatrace.com Support=https://www.dynatrace.com/support',
+        hostname         => 'apache-vm.puppet.vm',
+    }
+}
+```
 
-### `tenant_url` - required
+## Reference
 
-URL of your dynatrace Tenant
+Seen in file [REFERENCE.md]
 
-- Managed: `https://{your-domain}/e/{your-environment-id}`
-- SaaS: `https://{your-environment-id}.live.dynatrace.com`
+## Limitations
 
-### `paas_token` - required
+TBD
 
-PAAS token for downloading one agent installer
+## Development
 
-### `version` - optional
+TBD
 
-The required version of the OneAgent in 1.155.275.20181112-084458 format - default is latest
-
-### `arch` - optional
-
-The architecture of your OS - default is all
-
-### `installer_type` - optional
-
-The type of the installer - default is default
-
-### `download_dir` - optional
-
-OneAgent installer file download directory. Defaults are:
-
-- Linux/AIX : `/tmp/`
-- Windows   : `C:\Windows\Temp\`
-
-### `oneagent_params_hash` - optional
-
-Hash map of additional parameters to pass to the installer
-
-Default OneAgent install parameters defined in params.pp as a hash map:
-
-- `INFRA_ONLY => 0`
-- `APP_LOG_CONTENT_ACCESS => 1`
-
-### `reboot_system` - optional
-
-If set to true, puppet will reboot the server after installing the OneAgent - default is false
+[REFERENCE.md]: ./REFERENCE.md
+[puppet/archive]: https://forge.puppet.com/puppet/archive
+[puppet-labs/reboot]: https://forge.puppet.com/puppetlabs/reboots
+[dynatrace/dynatraceoneagent]:https://forge.puppet.com/dynatrace/dynatraceoneagent
+[Deployment API]: https://www.dynatrace.com/support/help/extend-dynatrace/dynatrace-api/environment-api/deployment/
+[Dynatrace Supported Operating Systems]:https://www.dynatrace.com/support/help/technology-support/operating-systems/
+[Deployment API - GET available versions of OneAgent]: https://www.dynatrace.com/support/help/extend-dynatrace/dynatrace-api/environment-api/deployment/oneagent/get-available-versions/
+[Handling file paths on Windows]: https://puppet.com/docs/puppet/4.10/lang_windows_file_paths.html

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Configure values to automatically add tags and metadata to a host and override a
         host_tags        => 'TestHost Gdansk role=fallback',
         host_metadata    => 'Environment=Prod Organization=D1P Owner=john.doe@dynatrace.com Support=https://www.dynatrace.com/support',
         hostname         => 'apache-vm.puppet.vm',
+        }
     }
-}
 ```
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -1,10 +1,32 @@
 # Dynatrace OneAgent module for puppet
 
-## Description
+### Table of Contents
+
+1. [Module Description - What the module does and why it is useful](#module-description)
+1. [Setup - The basics of getting started with the Dynatrace OneAgent](#setup)
+    * [What the Dynatrace OneAgent affects](#what-the-dynatrace-oneagent-affects)
+    * [Setup requirements](#setup-requirements)
+    * [Beginning with the Dynatrace OneAgent](#beginning-with-the-dynatrace-oneagent)
+1. [Usage - Configuration options and additional functionality](#usage)
+    * [Most basic OneAgent installation using a SAAS tenant](#most-basic-oneagent-installation-using-a-saas-tenant)
+    * [OneAgent installation using a managed tenant with a specific version](#oneagent-installation-using-a-managed-tenant-with-a-specific-version)
+    * [Advanced configuration](#advanced-configuration)
+    * [Setting tags, metadata and custom hostname](#setting-tags-metadata-and-custom-hostname)
+1. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
+1. [Limitations - OS compatibility, etc.](#limitations)
+1. [Development - Guide for contributing to the module](#development)
+
+## Module description
 
 This module deploys the Dynatrace OneAgent on Linux, Windows and AIX Operating Systems with different available configurations and ensures the OneAgent service maintains a running state. It provides the resource types to interact with the various OneAgent configuration files.
 
 ## Setup
+
+### What the Dynatrace OneAgent affects
+
+* Installs the Dynatrace OneAgent package with the selected parameters and manages its config files.
+* By default, enables the Dynatrace OneAgent boot-start, and uses the generated service file as part of the installer to manage the Dynatrace OneAgent service.
+* Any running processes prior to installing the OneAgent package will need to be restarted for full instrumentation, a server reboot is another alternative.
 
 ### Setup requirements
 
@@ -18,17 +40,21 @@ puppet module install dynatrace-dynatraceoneagent
 
 You will then need to supply the dynatraceoneagent class with two critical pieces of information.
 
-- The tenant URL: **Managed** `https://{your-domain}/e/{your-environment-id}` |  **SaaS** `https://{your-environment-id}.live.dynatrace.com`
-- The PaaS token of your environment for downloading the OneAgent installer
+* The tenant URL: **Managed** `https://{your-domain}/e/{your-environment-id}` |  **SaaS** `https://{your-environment-id}.live.dynatrace.com`
+* The PaaS token of your environment for downloading the OneAgent installer
 
 Refer to the customize OneAgent installation documentation on [Dynatrace Supported Operating Systems]
 This module uses the Dynatrace deployment API for downloading the installer for each supported OS. See [Deployment API]
+
+### Beginning with the Dynatrace OneAgent
+
+Once the Dynatrace OneAgent packages are downloaded to the target hosts using the archive module, the module is ready to deploy.
 
 ## Usage
 
 Default OneAgent install parameters defined in params.pp as a hash map: INFRA_ONLY=0, APP_LOG_CONTENT_ACCESS=1
 
-Most basic OneAgent installation using a SAAS tenant:
+### Most basic OneAgent installation using a SAAS tenant
 
 ```bash
     class { 'dynatraceoneagent':

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3,9 +3,15 @@
 
 ## Classes
 
-### dynatraceoneagent
+### Public Classes
 
-Install and configure the Dynatrace OneAgent.
+* `dynatraceoneagent`: Install and configure the Dynatrace OneAgent.
+
+### Private classes
+
+* `dynatraceoneagent::configure`: Handles the configuration of the Dynatrace OneAgent.
+* `dynatraceoneagent::install`: Handles the Dynatrace Oneagent installation.
+* `dynatraceoneagent::service`: Handles the Dynatrace Oneagent service.
 
 ### Parameters
 
@@ -17,10 +23,10 @@ Data Type: `String`
 
 URL of your dynatrace Tenant
 
-- Managed: `https://{your-domain}/e/{your-environment-id}`
-- SaaS: `https://{your-environment-id}.live.dynatrace.com`
+* Managed: `https://{your-domain}/e/{your-environment-id}`
+* SaaS: `https://{your-environment-id}.live.dynatrace.com`
 
-Default value: $dynatraceoneagent::params::tenant_url
+Default value: undef
 
 #### `paas_token` - required
 
@@ -28,7 +34,7 @@ Data Type: `String`
 
 PAAS token for downloading one agent installer
 
-Default value: dynatraceoneagent::params::paas_token
+Default value: undef
 
 #### `version` - optional
 
@@ -44,7 +50,7 @@ Data Type: `String`
 
 The architecture of your OS
 
-Default value is all
+Default value: all
 
 #### `installer_type` - optional
 
@@ -62,12 +68,12 @@ OneAgent installer file download directory.
 
 Defaults values are:
 
-- Linux/AIX : `/tmp/`
-- Windows   : `C:\Windows\Temp\`
+* Linux/AIX : `/tmp/`
+* Windows   : `C:\\Windows\\Temp\\`
 
 #### `oneagent_params_hash` - optional
 
-Data Type: `String`
+Data Type: `Hash`
 
 Hash map of additional parameters to pass to the installer
 
@@ -75,8 +81,8 @@ Default OneAgent install parameters defined in params.pp as a hash map.
 
 Default values are:
 
-- `INFRA_ONLY => 0`
-- `APP_LOG_CONTENT_ACCESS => 1`
+* `INFRA_ONLY => 0`
+* `APP_LOG_CONTENT_ACCESS => 1`
 
 #### `reboot_system` - optional
 
@@ -92,7 +98,7 @@ Data Type: `String`
 
 Values to automatically add tags to a host, should contain a list of strings or key/value pairs. Spaces are used to separate tag values.
 
-Default value: $dynatraceoneagent::params::host_tags
+Default value: undef
 
 #### `host_metadata` - optional
 
@@ -100,7 +106,7 @@ Data Type: `String`
 
 Values to automatically add metadata to a host, should contain a list of strings or key/value pairs. Spaces are used to separate metadata values.
 
-Default value: $dynatraceoneagent::params::host_metadata
+Default value: undef
 
 #### `hostname` - optional
 
@@ -108,4 +114,4 @@ Data Type: `String`
 
 Overrides an automatically detected host name.
 
-Default value: $dynatraceoneagent::params::hostname
+Default value: undef

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,0 +1,111 @@
+
+# Reference
+
+## Classes
+
+### dynatraceoneagent
+
+Install and configure the Dynatrace OneAgent.
+
+### Parameters
+
+The following parameters are available in the dynatraceoneagent class.
+
+#### `tenant_url` - required
+
+Data Type: `String`
+
+URL of your dynatrace Tenant
+
+- Managed: `https://{your-domain}/e/{your-environment-id}`
+- SaaS: `https://{your-environment-id}.live.dynatrace.com`
+
+Default value: $dynatraceoneagent::params::tenant_url
+
+#### `paas_token` - required
+
+Data Type: `String`
+
+PAAS token for downloading one agent installer
+
+Default value: dynatraceoneagent::params::paas_token
+
+#### `version` - optional
+
+Data Type: `String`
+
+The required version of the OneAgent in 1.155.275.20181112-084458 format
+
+Default value: latest
+
+#### `arch` - optional
+
+Data Type: `String`
+
+The architecture of your OS
+
+Default value is all
+
+#### `installer_type` - optional
+
+Data Type: `String`
+
+The type of the installer
+
+Default value: default
+
+#### `download_dir` - optional
+
+Data Type: `String`
+
+OneAgent installer file download directory.
+
+Defaults values are:
+
+- Linux/AIX : `/tmp/`
+- Windows   : `C:\Windows\Temp\`
+
+#### `oneagent_params_hash` - optional
+
+Data Type: `String`
+
+Hash map of additional parameters to pass to the installer
+
+Default OneAgent install parameters defined in params.pp as a hash map.
+
+Default values are:
+
+- `INFRA_ONLY => 0`
+- `APP_LOG_CONTENT_ACCESS => 1`
+
+#### `reboot_system` - optional
+
+Data Type: `Boolean`
+
+If set to true, puppet will reboot the server after installing the OneAgent
+
+Default: false
+
+#### `host_tags` - optional
+
+Data Type: `String`
+
+Values to automatically add tags to a host, should contain a list of strings or key/value pairs. Spaces are used to separate tag values.
+
+Default value: $dynatraceoneagent::params::host_tags
+
+#### `host_metadata` - optional
+
+Data Type: `String`
+
+Values to automatically add metadata to a host, should contain a list of strings or key/value pairs. Spaces are used to separate metadata values.
+
+Default value: $dynatraceoneagent::params::host_metadata
+
+#### `hostname` - optional
+
+Data Type: `String`
+
+Overrides an automatically detected host name.
+
+Default value: $dynatraceoneagent::params::hostname

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,46 @@
+# Class: dynatraceoneagent::config:  See README.md for documentation.
+# ===========================
+#
+#
+class dynatraceoneagent::config {
+
+  $host_tags                      = $dynatraceoneagent::host_tags
+  $host_metadata                  = $dynatraceoneagent::host_metadata
+  $hostname                       = $dynatraceoneagent::hostname
+  $hostautotag_config_file        = $dynatraceoneagent::hostautotag_config_file
+  $hostmetadata_config_file       = $dynatraceoneagent::hostmetadata_config_file
+  $hostname_config_file           = $dynatraceoneagent::hostname_config_file
+  $service_name                   = $dynatraceoneagent::service_name
+
+  if !$host_tags {
+    $auto_tag = ''
+  } else{
+    $auto_tag = $host_tags
+  }
+
+  if !$host_metadata {
+    $auto_metadata = ''
+  } else{
+    $auto_metadata = $host_metadata
+  }
+
+  if !$hostname {
+    $auto_hostname = ''
+  } else{
+    $auto_hostname = $hostname
+  }
+
+  file { $hostautotag_config_file:
+    content => $auto_tag,
+  }
+
+  file { $hostmetadata_config_file:
+    content => $auto_metadata,
+  }
+
+  file { $hostname_config_file:
+    content => $auto_hostname,
+    notify  => Service[$service_name],
+  }
+
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,35 +12,23 @@ class dynatraceoneagent::config {
   $hostname_config_file           = $dynatraceoneagent::hostname_config_file
   $service_name                   = $dynatraceoneagent::service_name
 
-  if !$host_tags {
-    $auto_tag = ''
-  } else{
-    $auto_tag = $host_tags
+  if $host_tags {
+    file { $hostautotag_config_file:
+      content => $host_tags,
+    }
   }
 
-  if !$host_metadata {
-    $auto_metadata = ''
-  } else{
-    $auto_metadata = $host_metadata
-  }
+  if $host_metadata {
+    file { $hostmetadata_config_file:
+      content => $host_metadata,
+    }
+  } 
 
-  if !$hostname {
-    $auto_hostname = ''
-  } else{
-    $auto_hostname = $hostname
-  }
-
-  file { $hostautotag_config_file:
-    content => $auto_tag,
-  }
-
-  file { $hostmetadata_config_file:
-    content => $auto_metadata,
-  }
-
-  file { $hostname_config_file:
-    content => $auto_hostname,
-    notify  => Service[$service_name],
+  if $hostname {
+    file { $hostname_config_file:
+      content => $hostname,
+      notify  => Service[$service_name],
+    }
   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,21 +14,38 @@ class dynatraceoneagent::config {
 
   if $host_tags {
     file { $hostautotag_config_file:
+      ensure  => present,
       content => $host_tags,
     }
-  }
+  } else {
+      file { $hostautotag_config_file:
+        ensure  => present,
+        content => '',
+      }
+    }
 
   if $host_metadata {
     file { $hostmetadata_config_file:
+      ensure  => present,
       content => $host_metadata,
     }
-  } 
+  } else {
+      file { $hostmetadata_config_file:
+        ensure  => absent,
+      }
+   }
 
   if $hostname {
     file { $hostname_config_file:
+      ensure  => present,
       content => $hostname,
       notify  => Service[$service_name],
     }
-  }
+  } else {
+      file { $hostname_config_file:
+        ensure  => absent,
+        notify  => Service[$service_name],
+        } 
+   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,23 +17,25 @@ class dynatraceoneagent::config {
       ensure  => present,
       content => $host_tags,
     }
-  } else {
-      file { $hostautotag_config_file:
-        ensure  => present,
-        content => '',
-      }
+  }
+  else {
+    file { $hostautotag_config_file:
+      ensure  => present,
+      content => '',
     }
+  }
 
   if $host_metadata {
     file { $hostmetadata_config_file:
       ensure  => present,
       content => $host_metadata,
     }
-  } else {
-      file { $hostmetadata_config_file:
-        ensure  => absent,
-      }
-   }
+  }
+  else {
+    file { $hostmetadata_config_file:
+      ensure  => absent,
+    }
+  }
 
   if $hostname {
     file { $hostname_config_file:
@@ -41,11 +43,12 @@ class dynatraceoneagent::config {
       content => $hostname,
       notify  => Service[$service_name],
     }
-  } else {
-      file { $hostname_config_file:
-        ensure  => absent,
-        notify  => Service[$service_name],
-        } 
-   }
+  }
+  else {
+    file { $hostname_config_file:
+      ensure => absent,
+      notify => Service[$service_name],
+    }
+  }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,8 @@
 # Class: dynatraceoneagent  See README.md for documentation.
 # ============================================
 #
-# This module deploys the OneAgent on Linux, Windows and AIX Operating Systems with different available configurations and 
-# ensures the OneAgent service maintains a running state. It provides types/providers to interact with the various OneAgent configuration files.
+# This module deploys the OneAgent on Linux, Windows and AIX Operating Systems with different available configurations and ensures
+# the OneAgent service maintains a running state. It provides types/providers to interact with the various OneAgent configuration files.
 #
 #   Parameters for the OneAgent Download:
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,8 @@
 # Class: dynatraceoneagent  See README.md for documentation.
 # ============================================
 #
-# This module installs the dynatrace one agent on the host.
-# Currently supported for Linux, AIX and Windows Operating Systems
+# This module deploys the OneAgent on Linux, Windows and AIX Operating Systems with different available configurations and 
+# ensures the OneAgent service maintains a running state. It provides types/providers to interact with the various OneAgent configuration files.
 #
 #   Parameters for the OneAgent Download:
 #
@@ -16,7 +16,7 @@
 #   Parameters for the OneAgent Installer:
 #   * download_dir                => OneAgent installer file download directory. Defaults are
 #                                    Linux/AIX : /tmp/
-#                                    Windows   : C:\Windows\Temp\
+#                                    Windows   : C:\\Windows\\Temp\\
 #
 #   * oneagent_params_hash        => Hash map of additional parameters to pass to the installer
 #   * Default OneAgent install parameters defined in params.pp as a hash map: 'INFRA_ONLY=0', 'APP_LOG_CONTENT_ACCESS=1'
@@ -29,25 +29,44 @@
 #     }
 #   Refer to the Customize OneAgent installation documentation on https://www.dynatrace.com/support/help/technology-support/operating-systems/
 #   * $reboot_system                => If set to true, puppet will reboot the server after installing the OneAgent - default is false
+#
+#   OneAgent Host Configuration Parameters:
+#
+#   * $host_tags                    => Values to automatically add tags to a host, should contain a list of strings or key/value paris. 
+#                                      Spaces are used to separate tag values. For example: 
+#                                      TestHost Gdansk role=fallback
+#   * $host_metadata                => Values to automatically add metadata to a host, should contain a list of strings or key/value pairs.
+#                                      Spaces are used to separate metadata values. For example: 
+#                                      Environment=Dev Organization=D1P Owner=john.doe@dynatrace.com Support=https://www.dynatrace.com/support
+#   * $hostname                     => Overrides an automatically detected host name. Example: My App Server
 
 class dynatraceoneagent (
 
 # OneAgent Download Parameters
   String $tenant_url                    = $dynatraceoneagent::params::tenant_url,
   String $paas_token                    = $dynatraceoneagent::params::paas_token,
+  String $api_path                      = $dynatraceoneagent::params::api_path,
   String $version                       = $dynatraceoneagent::params::version,
   String $arch                          = $dynatraceoneagent::params::arch,
   String $installer_type                = $dynatraceoneagent::params::installer_type,
   String $os_type                       = $dynatraceoneagent::params::os_type,
 
-#OneAgent Install Parameters
+# OneAgent Install Parameters
   String $download_dir                   = $dynatraceoneagent::params::download_dir,
   String $service_name                   = $dynatraceoneagent::params::service_name,
   String $provider                       = $dynatraceoneagent::params::provider,
   String $default_install_dir            = $dynatraceoneagent::params::default_install_dir,
   Hash $oneagent_params_hash             = $dynatraceoneagent::params::oneagent_params_hash,
-
   Boolean $reboot_system                 = $dynatraceoneagent::params::reboot_system,
+
+# OneAgent Host Configuration Parameters
+
+  Optional[String] $host_tags            = $dynatraceoneagent::params::host_tags,
+  Optional[String] $host_metadata        = $dynatraceoneagent::params::host_metadata,
+  Optional[String] $hostname             = $dynatraceoneagent::params::hostname,
+  String $hostautotag_config_file        = $dynatraceoneagent::params::hostautotag_config_file,
+  String $hostmetadata_config_file       = $dynatraceoneagent::params::hostmetadata_config_file,
+  String $hostname_config_file           = $dynatraceoneagent::params::hostname_config_file,
 
 ) inherits dynatraceoneagent::params {
 
@@ -58,9 +77,9 @@ class dynatraceoneagent (
     }
 
     if $version == 'latest' {
-      $download_link  = "${tenant_url}/api/v1/deployment/installer/agent/${os_type}/${installer_type}/latest/?Api-Token=${paas_token}&flavor=default&arch=${arch}"
+      $download_link  = "${tenant_url}${api_path}${os_type}/${installer_type}/latest/?Api-Token=${paas_token}&arch=${arch}"
     } else {
-      $download_link  = "${tenant_url}/api/v1/deployment/installer/agent/${os_type}/${installer_type}/version/${version}?Api-Token=${paas_token}&flavor=default&arch=${arch}"
+      $download_link  = "${tenant_url}${api_path}${os_type}/${installer_type}/version/${version}?Api-Token=${paas_token}&arch=${arch}"
     }
 
     if $::osfamily == 'Windows' {
@@ -79,8 +98,10 @@ class dynatraceoneagent (
   #notify { "params hash is: ${oneagent_params_hash}": }
 
   contain dynatraceoneagent::install
+  contain dynatraceoneagent::config
   contain dynatraceoneagent::service
 
   Class['::dynatraceoneagent::install']
+  ~> Class['::dynatraceoneagent::config']
   ~> Class['::dynatraceoneagent::service']
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,6 @@ class dynatraceoneagent (
   contain dynatraceoneagent::service
 
   Class['::dynatraceoneagent::install']
-  ~> Class['::dynatraceoneagent::config']
-  ~> Class['::dynatraceoneagent::service']
+  -> Class['::dynatraceoneagent::config']
+  -> Class['::dynatraceoneagent::service']
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,33 +8,45 @@ class dynatraceoneagent::params {
     # OneAgent Download Parameters
     $tenant_url         = undef
     $paas_token         = undef
+    $api_path           = '/api/v1/deployment/installer/agent/'
     $version            = 'latest'
     $arch               = 'all'
     $installer_type     = 'default'
 
-    #OneAgent Install Parameters
+    # OneAgent Install Parameters
     $oneagent_params_hash = {
         'INFRA_ONLY'             => '0',
         'APP_LOG_CONTENT_ACCESS' => '1',
     }
-
     $reboot_system      = false
+
+    # OneAgent Host Configuration Parameters
+
+    $host_tags          = undef
+    $host_metadata      = undef
+    $hostname           = undef
 
     if $::osfamily == 'Windows' {
         #Parameters for Windows OneAgent Download
-        $os_type        = 'windows'
-        $download_dir   = 'C:\\Windows\\Temp\\'
+        $os_type                  = 'windows'
+        $download_dir             = 'C:\\Windows\\Temp\\'
         #Parameters for Windows OneAgent Installer
-        $service_name   = 'Dynatrace OneAgent'
-        $provider       = 'windows'
+        $service_name             = 'Dynatrace OneAgent'
+        $provider                 = 'windows'
+        $hostautotag_config_file  = "${::common_appdata}\\dynatrace\\oneagent\\agent\\config\\hostautotag.conf"
+        $hostmetadata_config_file = "${::common_appdata}\\dynatrace\\oneagent\\agent\\config\\hostcustomproperties.conf"
+        $hostname_config_file     = "${::common_appdata}\\dynatrace\\oneagent\\agent\\config\\hostname.conf"
     } elsif $::osfamily == 'AIX' {
         #Parameters for AIX OneAgent Download
-        $os_type        = 'aix'
-        $download_dir   = '/tmp/'
+        $os_type             = 'aix'
+        $download_dir        = '/tmp/'
         #Parameters for AIX OneAgent Installer
-        $service_name   = 'oneagent'
-        $provider       = 'shell'
+        $service_name        = 'oneagent'
+        $provider            = 'shell'
         $default_install_dir = '/opt/dynatrace/oneagent'
+        $hostautotag_config_file  = '/var/lib/dynatrace/oneagent/agent/config/hostautotag.conf'
+        $hostmetadata_config_file = '/var/lib/dynatrace/oneagent/agent/config/hostcustomproperties.conf'
+        $hostname_config_file     = '/var/lib/dynatrace/oneagent/agent/config/hostname.conf'
     } elsif $::kernel == 'Linux' {
         #Parameters for Linux OneAgent Download
         $os_type        = 'unix'
@@ -43,6 +55,9 @@ class dynatraceoneagent::params {
         $service_name   = 'oneagent'
         $provider       = 'shell'
         $default_install_dir = '/opt/dynatrace/oneagent'
+        $hostautotag_config_file = '/var/lib/dynatrace/oneagent/agent/config/hostautotag.conf'
+        $hostmetadata_config_file = '/var/lib/dynatrace/oneagent/agent/config/hostcustomproperties.conf'
+        $hostname_config_file = '/var/lib/dynatrace/oneagent/agent/config/hostname.conf'
     }
 
     #Set default install dir based on Windows architecture

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -53,14 +53,14 @@ class dynatraceoneagent::service {
         refreshonly => true,
         subscribe   => Exec['install_oneagent'],
     }
-  } else {
-    notify { 'Not rebooting': }
   }
 
   service{ $service_name:
-      ensure  => running,
-      enable  => true,
-      require => $require_value,
+      ensure     => running,
+      enable     => true,
+      hasstatus  => true,
+      hasrestart => true,
+      require    => $require_value,
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "dynatrace-dynatraceoneagent",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "author": "Dynatrace LLC",
   "summary": "This puppet module downloads and installs the dynatrace OneAgent agent on windows, linux and AIX systems",
   "license": "MIT",
@@ -72,7 +72,7 @@
       "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.14.1",
-  "template-url": "pdk-default#1.14.1",
-  "template-ref": "1.14.1-0-g0b5b39b"
+  "pdk-version": "1.16.0",
+  "template-url": "pdk-default#1.16.0",
+  "template-ref": "tags/1.16.0-0-gaf44904"
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 


### PR DESCRIPTION
Features added

- Ability to set string values to the hostcustomproperties.conf and hostautotag.conf of the OneAgent config to add tags and metadata to a host entity.
- Ability to override the automatically detected hostname by setting the values of the hostname.conf file and restarting the Dynatrace OneAgent service.