### PR TITLE
Added input for proxy_server

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,7 @@ class dynatraceoneagent (
   String $arch                          = $dynatraceoneagent::params::arch,
   String $installer_type                = $dynatraceoneagent::params::installer_type,
   String $os_type                       = $dynatraceoneagent::params::os_type,
+  String $proxy_server                  = $dynatraceoneagent::params::proxy_server,
 
 # OneAgent Install Parameters
   String $download_dir                   = $dynatraceoneagent::params::download_dir,


### PR DESCRIPTION
The actual setting for the proxy server is missing from the dynatraceoneagent class.