### PR TITLE
Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.6.0
+
+### Features
+
+ - Use shell (`/bin/sh`) to run OneAgent install script on Linux and AIX systems
+ - Remove resource `file{ $download_path:}` as it is not needed anymore with the addition of shell to the install OneAgent command
+
+### Bugfixes
+
+ - Fixed if statements with missing or with wrong conditions that checked for the AIX/Linux Operating System from the host facts.
+
+### Known Issues
+
+TBD
+
 ## Release 1.5.0
 
 ### Features

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,7 +36,7 @@ class dynatraceoneagent::config {
   $oneagent_infraonly_config_file      = $dynatraceoneagent::oneagent_infraonly_config_file
   $oneagent_networkzone_config_file    = $dynatraceoneagent::oneagent_networkzone_config_file
 
-  if ($package_state == 'absent') and ($::kernel == 'Linux') or ($::osfamily == 'AIX') {
+  if ($package_state == 'absent') and ($::kernel == 'Linux' or $::osfamily == 'AIX') {
       exec { 'uninstall_oneagent':
         command   => "${install_dir}/agent/uninstall.sh",
         timeout   => 6000,

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -45,13 +45,7 @@ class dynatraceoneagent::download {
     }
   }
 
-  if $package_state != 'absent' {
-    file{ $download_path:
-      mode   => '0755',
-    }
-  }
-
-  if ($dynatraceoneagent::verify_signature) and ($package_state != 'absent') and ($::kernel == 'Linux') {
+  if ($::kernel == 'Linux' or $::osfamily  == 'AIX') and ($dynatraceoneagent::verify_signature) and ($package_state != 'absent'){
 
     archive{ $dynatraceoneagent::cert_file_name:
       ensure         => present,
@@ -81,7 +75,10 @@ class dynatraceoneagent::download {
         provider  => $provider,
         logoutput => on_failure,
         unless    => $verify_signature_command,
-        require   => File[$dynatraceoneagent::dt_root_cert, $download_path],
+        require   => [
+            File[$dynatraceoneagent::dt_root_cert],
+            Archive[$filename],
+        ],
         creates   => $created_dir,
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -178,7 +178,7 @@ class dynatraceoneagent (
       $dt_root_cert             = "${download_dir}/${cert_file_name}"
       $oneagent_params_array    = $oneagent_params_hash.map |$key,$value| { "${key}=${value}" }
       $oneagent_unix_params     = join($oneagent_params_array, ' ' )
-      $command                  = "${download_path} ${oneagent_unix_params}"
+      $command                  = "/bin/sh ${download_path} ${oneagent_unix_params}"
       $created_dir              = "${install_dir}/agent/agent.state"
       $oneagent_tools_dir       = "${$install_dir}/agent/tools"
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,7 +14,7 @@ class dynatraceoneagent::install {
   $package_state            = $dynatraceoneagent::package_state
   $oneagent_puppet_conf_dir = $dynatraceoneagent::oneagent_puppet_conf_dir
 
-  if ($::kernel == 'Linux') and ($package_state != 'absent') {
+  if ($::kernel == 'Linux' or $::osfamily  == 'AIX') and ($package_state != 'absent') {
     exec { 'install_oneagent':
         command   => $dynatraceoneagent::command,
         cwd       => $download_dir,
@@ -38,7 +38,7 @@ class dynatraceoneagent::install {
     reboot { 'after':
       subscribe => Package[$service_name],
     }
-  } elsif ($::kernel == 'Linux') and ($reboot_system) and ($package_state != 'absent') {
+  } elsif ($::kernel == 'Linux' or $::osfamily  == 'AIX') and ($reboot_system) and ($package_state != 'absent') {
       reboot { 'after':
         subscribe => Exec['install_oneagent'],
       }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "dynatrace-dynatraceoneagent",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": "Dynatrace LLC",
   "summary": "This puppet module downloads and installs the dynatrace OneAgent agent on windows, linux and AIX systems",
   "license": "MIT",

--- a/provision.yaml
+++ b/provision.yaml
@@ -1,6 +1,6 @@
 ---
   vagrant:
     provisioner: vagrant
-    images: ['generic/ubuntu1804', 'generic/ubuntu2004', 'generic/debian9', 'centos/7', 'gusztavvargadr/windows-server']
+    images: ['generic/ubuntu1804', 'generic/ubuntu2004', 'generic/debian9', 'gusztavvargadr/windows-server']
     params:
       vagrant_provider: virtualbox


### PR DESCRIPTION
## Release 1.6.0

### Features

 - Use shell (`/bin/sh`) to run OneAgent install script on Linux and AIX systems
 - Remove resource `file{ $download_path:}` as it is not needed anymore with the addition of shell to the install OneAgent command

### Bugfixes

 - Fixed if statements with missing or with wrong conditions that checked for the AIX/Linux Operating System from the host facts.