### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.7.0
+
+### Features
+
+ - Add download_options parameter on Archive resource in case custom flags are needed for curl/wget/s3 when downloading the OneAgent installer
+
+### Bugfixes
+
+ - Added `--restart-service` parameter to `oneagentctl --set-network-zone` command
+
+### Known Issues
+
+TBD
+
 ## Release 1.6.0
 
 ### Features

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -133,6 +133,15 @@ Ignore HTTPS certificate errors when using the archive module.
 
 Default value: $dynatraceoneagent::params::allow_insecure
 
+##### `download_options`
+
+Data type: `Optional`
+
+In some cases you may need custom flags for curl/wget/s3 which can be supplied via download_options.
+Refer to [Download Customizations](https://github.com/voxpupuli/puppet-archive#download-customizations)
+
+Default value: $dynatraceoneagent::params::download_options
+
 ##### `download_dir`
 
 Data type: `String`
@@ -384,3 +393,4 @@ This class manages the OneAgent parameters
 ### dynatraceoneagent::service
 
 Manages the OneAgent service
+

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -317,7 +317,7 @@ class dynatraceoneagent::config {
     }
 
     exec { 'set_network_zone':
-        command     => "${oactl} --set-network-zone=${network_zone}",
+        command     => "${oactl} --set-network-zone=${network_zone} --restart-service",
         path        => $oneagentctl_exec_path,
         cwd         => $oneagent_tools_dir,
         timeout     => 6000,
@@ -327,7 +327,7 @@ class dynatraceoneagent::config {
     }
 
     exec { 'unset_network_zone':
-        command     => "${oactl} --set-network-zone=\"\"",
+        command     => "${oactl} --set-network-zone=\"\" --restart-service",
         path        => $oneagentctl_exec_path,
         cwd         => $oneagent_tools_dir,
         timeout     => 6000,

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -15,6 +15,7 @@ class dynatraceoneagent::download {
   $download_path            = $dynatraceoneagent::download_path
   $proxy_server             = $dynatraceoneagent::proxy_server
   $allow_insecure           = $dynatraceoneagent::allow_insecure
+  $download_options         = $dynatraceoneagent::download_options
   $download_link            = $dynatraceoneagent::download_link
   $download_cert_link       = $dynatraceoneagent::download_cert_link
   $cert_file_name           = $dynatraceoneagent::cert_file_name
@@ -48,15 +49,16 @@ class dynatraceoneagent::download {
   if ($::kernel == 'Linux' or $::osfamily  == 'AIX') and ($dynatraceoneagent::verify_signature) and ($package_state != 'absent'){
 
     archive{ $dynatraceoneagent::cert_file_name:
-      ensure         => present,
-      extract        => false,
-      source         => $download_cert_link,
-      path           => $dynatraceoneagent::dt_root_cert,
-      allow_insecure => $allow_insecure,
-      require        => File[$download_dir],
-      creates        => $dynatraceoneagent::cert_file_name,
-      proxy_server   => $proxy_server,
-      cleanup        => false,
+      ensure           => present,
+      extract          => false,
+      source           => $download_cert_link,
+      path             => $dynatraceoneagent::dt_root_cert,
+      allow_insecure   => $allow_insecure,
+      require          => File[$download_dir],
+      creates          => $dynatraceoneagent::cert_file_name,
+      proxy_server     => $proxy_server,
+      cleanup          => false,
+      download_options => $download_options
     }
 
     file{ $dynatraceoneagent::dt_root_cert:

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -58,7 +58,7 @@ class dynatraceoneagent::download {
       creates          => $dynatraceoneagent::cert_file_name,
       proxy_server     => $proxy_server,
       cleanup          => false,
-      download_options => $download_options
+      download_options => $download_options,
     }
 
     file{ $dynatraceoneagent::dt_root_cert:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,9 @@
 #   Name of the downloaded cert file
 # @param allow_insecure
 #   Ignore HTTPS certificate errors when using the archive module.
+# @param download_options
+#   In some cases you may need custom flags for curl/wget/s3 which can be supplied via download_options.
+#   Refer to [Download Customizations](https://github.com/voxpupuli/puppet-archive#download-customizations)
 # @param download_dir
 #   OneAgent installer file download directory.
 # @param default_install_dir
@@ -114,6 +117,7 @@ class dynatraceoneagent (
   Optional[String] $download_cert_link  = $dynatraceoneagent::params::download_cert_link,
   Optional[String] $cert_file_name      = $dynatraceoneagent::params::cert_file_name,
   Optional[Boolean] $allow_insecure     = $dynatraceoneagent::params::allow_insecure,
+  Optional $download_options            = $dynatraceoneagent::params::download_options,
 
 # OneAgent Install Parameters
   String $download_dir                   = $dynatraceoneagent::params::download_dir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class dynatraceoneagent::params {
     $proxy_server       = undef
     $allow_insecure     = false
     $verify_signature   = false
+    $download_options   = undef
     $download_cert_link = 'https://ca.dynatrace.com/dt-root.cert.pem'
     $cert_file_name     = 'dt-root.cert.pem'
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "dynatrace-dynatraceoneagent",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": "Dynatrace LLC",
   "summary": "This puppet module downloads and installs the dynatrace OneAgent agent on windows, linux and AIX systems",
   "license": "MIT",


### PR DESCRIPTION
### Features

 - Add download_options parameter on Archive resource in case custom flags are needed for curl/wget/s3 when downloading the OneAgent installer

### Bugfixes

 - Added `--restart-service` parameter to `oneagentctl --set-network-zone` command