### PR TITLE
add manage_service parameter

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -9,24 +9,24 @@ class dynatraceoneagent::download {
     }
   }
 
-  $created_dir              = $dynatraceoneagent::created_dir
-  $download_dir             = $dynatraceoneagent::download_dir
-  $filename                 = $dynatraceoneagent::filename
-  $download_path            = $dynatraceoneagent::download_path
-  $proxy_server             = $dynatraceoneagent::proxy_server
-  $allow_insecure           = $dynatraceoneagent::allow_insecure
-  $download_options         = $dynatraceoneagent::download_options
-  $download_link            = $dynatraceoneagent::download_link
-  $download_cert_link       = $dynatraceoneagent::download_cert_link
-  $cert_file_name           = $dynatraceoneagent::cert_file_name
-  $provider                 = $dynatraceoneagent::provider
-  $oneagent_params_hash     = $dynatraceoneagent::oneagent_params_hash
-  $reboot_system            = $dynatraceoneagent::reboot_system
-  $service_name             = $dynatraceoneagent::service_name
-  $package_state            = $dynatraceoneagent::package_state
-  $global_owner             = $dynatraceoneagent::global_owner
-  $global_group             = $dynatraceoneagent::global_group
-  $global_mode              = $dynatraceoneagent::global_mode
+  $created_dir          = $dynatraceoneagent::created_dir
+  $download_dir         = $dynatraceoneagent::download_dir
+  $filename             = $dynatraceoneagent::filename
+  $download_path        = $dynatraceoneagent::download_path
+  $proxy_server         = $dynatraceoneagent::proxy_server
+  $allow_insecure       = $dynatraceoneagent::allow_insecure
+  $download_options     = $dynatraceoneagent::download_options
+  $download_link        = $dynatraceoneagent::download_link
+  $download_cert_link   = $dynatraceoneagent::download_cert_link
+  $cert_file_name       = $dynatraceoneagent::cert_file_name
+  $provider             = $dynatraceoneagent::provider
+  $oneagent_params_hash = $dynatraceoneagent::oneagent_params_hash
+  $reboot_system        = $dynatraceoneagent::reboot_system
+  $service_name         = $dynatraceoneagent::service_name
+  $package_state        = $dynatraceoneagent::package_state
+  $global_owner         = $dynatraceoneagent::global_owner
+  $global_group         = $dynatraceoneagent::global_group
+  $global_mode          = $dynatraceoneagent::global_mode
 
   if $package_state != 'absent' {
     file{ $download_dir:
@@ -71,17 +71,17 @@ class dynatraceoneagent::download {
      cat ${download_path} ) | openssl cms -verify -CAfile ${dynatraceoneagent::dt_root_cert} > /dev/null"
 
     exec { 'delete_oneagent_installer_script':
-        command   => "rm ${$download_path}",
-        cwd       => $download_dir,
-        timeout   => 6000,
-        provider  => $provider,
-        logoutput => on_failure,
-        unless    => $verify_signature_command,
-        require   => [
-            File[$dynatraceoneagent::dt_root_cert],
-            Archive[$filename],
-        ],
-        creates   => $created_dir,
+      command   => "rm ${$download_path}",
+      cwd       => $download_dir,
+      timeout   => 6000,
+      provider  => $provider,
+      logoutput => on_failure,
+      unless    => $verify_signature_command,
+      require   => [
+        File[$dynatraceoneagent::dt_root_cert],
+        Archive[$filename],
+      ],
+      creates   => $created_dir,
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,85 +3,86 @@
 #
 class dynatraceoneagent::params {
 
-    $global_mode = '0644'
+  $global_mode = '0644'
 
-    # OneAgent Download Parameters
-    $tenant_url         = undef
-    $paas_token         = undef
-    $api_path           = '/api/v1/deployment/installer/agent/'
-    $version            = 'latest'
-    $arch               = 'all'
-    $installer_type     = 'default'
-    $proxy_server       = undef
-    $allow_insecure     = false
-    $verify_signature   = false
-    $download_options   = undef
-    $download_cert_link = 'https://ca.dynatrace.com/dt-root.cert.pem'
-    $cert_file_name     = 'dt-root.cert.pem'
+  # OneAgent Download Parameters
+  $tenant_url         = undef
+  $paas_token         = undef
+  $api_path           = '/api/v1/deployment/installer/agent/'
+  $version            = 'latest'
+  $arch               = 'all'
+  $installer_type     = 'default'
+  $proxy_server       = undef
+  $allow_insecure     = false
+  $verify_signature   = false
+  $download_options   = undef
+  $download_cert_link = 'https://ca.dynatrace.com/dt-root.cert.pem'
+  $cert_file_name     = 'dt-root.cert.pem'
 
-    # OneAgent Install Parameters
-    $oneagent_params_hash = {
-        '--set-infra-only'             => 'false',
-        '--set-app-log-content-access' => 'true',
-    }
-    $reboot_system      = false
-    $service_state      = 'running'
-    $package_state      = 'present'
+  # OneAgent Install Parameters
+  $oneagent_params_hash = {
+    '--set-infra-only'             => 'false',
+    '--set-app-log-content-access' => 'true',
+  }
+  $reboot_system      = false
+  $manage_service     = true
+  $service_state      = 'running'
+  $package_state      = 'present'
 
-    # OneAgent Host Configuration Parameters
-    $host_tags                   = []
-    $host_metadata               = []
-    $hostname                    = undef
-    $oneagent_communication_hash = {}
-    $log_monitoring              = undef
-    $log_access                  = undef
-    $host_group                  = undef
-    $infra_only                  = undef
-    $network_zone                = undef
+  # OneAgent Host Configuration Parameters
+  $host_tags                   = []
+  $host_metadata               = []
+  $hostname                    = undef
+  $oneagent_communication_hash = {}
+  $log_monitoring              = undef
+  $log_access                  = undef
+  $host_group                  = undef
+  $infra_only                  = undef
+  $network_zone                = undef
 
-    if $::osfamily == 'Windows' {
-        #Parameters for Windows OneAgent Download
-        $os_type                    = 'windows'
-        $download_dir               = 'C:\\Windows\\Temp'
-        #Parameters for Windows OneAgent Installer
-        $global_owner                       = 'Administrator'
-        $global_group                       = 'Administrators'
-        $service_name                       = 'Dynatrace OneAgent'
-        $provider                           = 'windows'
-        $default_install_dir                = "${::dynatrace_oneagent_programfiles}\\dynatrace\\oneagent"
-        $oneagent_ctl                       = 'oneagentctl.exe'
-        $windows_pwsh                       = "${::system32}\\WindowsPowerShell\\v1.0"
-        $require_value                      = Package[$service_name]
-        $oneagent_puppet_conf_dir           = "${::dynatrace_oneagent_appdata}\\dynatrace\\oneagent\\agent\\config\\puppet"
-        $oneagent_comms_config_file         = "${oneagent_puppet_conf_dir}\\deployment.conf"
-        $oneagent_logmonitoring_config_file = "${oneagent_puppet_conf_dir}\\logmonitoring.conf"
-        $oneagent_logaccess_config_file     = "${oneagent_puppet_conf_dir}\\logaccess.conf"
-        $hostgroup_config_file              = "${oneagent_puppet_conf_dir}\\hostgroup.conf"
-        $hostautotag_config_file            = "${oneagent_puppet_conf_dir}\\puppethostautotag.conf"
-        $hostname_config_file               = "${oneagent_puppet_conf_dir}\\hostname.conf"
-        $hostmetadata_config_file           = "${oneagent_puppet_conf_dir}\\hostcustomproperties.conf"
-        $oneagent_infraonly_config_file     = "${oneagent_puppet_conf_dir}\\infraonly.conf"
-        $oneagent_networkzone_config_file   = "${oneagent_puppet_conf_dir}\\networkzone.conf"
-    } elsif ($::kernel == 'Linux') or ($::osfamily == 'AIX')  {
-        #Parameters for Linux/AIX OneAgent Download
-        $download_dir               = '/tmp'
-        #Parameters for Linux/AIX OneAgent Installer
-        $global_owner                       = 'root'
-        $global_group                       = 'root'
-        $service_name                       = 'oneagent'
-        $provider                           = 'shell'
-        $default_install_dir                = '/opt/dynatrace/oneagent'
-        $oneagent_ctl                       = 'oneagentctl'
-        $require_value                      = Exec['install_oneagent']
-        $oneagent_puppet_conf_dir           = '/var/lib/dynatrace/oneagent/agent/config/puppet'
-        $oneagent_comms_config_file         = "${oneagent_puppet_conf_dir}/deployment.conf"
-        $oneagent_logmonitoring_config_file = "${oneagent_puppet_conf_dir}/logmonitoring.conf"
-        $oneagent_logaccess_config_file     = "${oneagent_puppet_conf_dir}/logaccess.conf"
-        $hostgroup_config_file              = "${oneagent_puppet_conf_dir}/hostgroup.conf"
-        $hostautotag_config_file            = "${oneagent_puppet_conf_dir}/hostautotag.conf"
-        $hostmetadata_config_file           = "${oneagent_puppet_conf_dir}/hostcustomproperties.conf"
-        $hostname_config_file               = "${oneagent_puppet_conf_dir}/hostname.conf"
-        $oneagent_infraonly_config_file     = "${oneagent_puppet_conf_dir}/infraonly.conf"
-        $oneagent_networkzone_config_file   = "${oneagent_puppet_conf_dir}/networkzone.conf"
-    }
+  if $::osfamily == 'Windows' {
+    #Parameters for Windows OneAgent Download
+    $os_type                            = 'windows'
+    $download_dir                       = 'C:\\Windows\\Temp'
+    #Parameters for Windows OneAgent Installer
+    $global_owner                       = 'Administrator'
+    $global_group                       = 'Administrators'
+    $service_name                       = 'Dynatrace OneAgent'
+    $provider                           = 'windows'
+    $default_install_dir                = "${::dynatrace_oneagent_programfiles}\\dynatrace\\oneagent"
+    $oneagent_ctl                       = 'oneagentctl.exe'
+    $windows_pwsh                       = "${::system32}\\WindowsPowerShell\\v1.0"
+    $require_value                      = Package[$service_name]
+    $oneagent_puppet_conf_dir           = "${::dynatrace_oneagent_appdata}\\dynatrace\\oneagent\\agent\\config\\puppet"
+    $oneagent_comms_config_file         = "${oneagent_puppet_conf_dir}\\deployment.conf"
+    $oneagent_logmonitoring_config_file = "${oneagent_puppet_conf_dir}\\logmonitoring.conf"
+    $oneagent_logaccess_config_file     = "${oneagent_puppet_conf_dir}\\logaccess.conf"
+    $hostgroup_config_file              = "${oneagent_puppet_conf_dir}\\hostgroup.conf"
+    $hostautotag_config_file            = "${oneagent_puppet_conf_dir}\\puppethostautotag.conf"
+    $hostname_config_file               = "${oneagent_puppet_conf_dir}\\hostname.conf"
+    $hostmetadata_config_file           = "${oneagent_puppet_conf_dir}\\hostcustomproperties.conf"
+    $oneagent_infraonly_config_file     = "${oneagent_puppet_conf_dir}\\infraonly.conf"
+    $oneagent_networkzone_config_file   = "${oneagent_puppet_conf_dir}\\networkzone.conf"
+  } elsif ($::kernel == 'Linux') or ($::osfamily == 'AIX') {
+    #Parameters for Linux/AIX OneAgent Download
+    $download_dir                       = '/tmp'
+    #Parameters for Linux/AIX OneAgent Installer
+    $global_owner                       = 'root'
+    $global_group                       = 'root'
+    $service_name                       = 'oneagent'
+    $provider                           = 'shell'
+    $default_install_dir                = '/opt/dynatrace/oneagent'
+    $oneagent_ctl                       = 'oneagentctl'
+    $require_value                      = Exec['install_oneagent']
+    $oneagent_puppet_conf_dir           = '/var/lib/dynatrace/oneagent/agent/config/puppet'
+    $oneagent_comms_config_file         = "${oneagent_puppet_conf_dir}/deployment.conf"
+    $oneagent_logmonitoring_config_file = "${oneagent_puppet_conf_dir}/logmonitoring.conf"
+    $oneagent_logaccess_config_file     = "${oneagent_puppet_conf_dir}/logaccess.conf"
+    $hostgroup_config_file              = "${oneagent_puppet_conf_dir}/hostgroup.conf"
+    $hostautotag_config_file            = "${oneagent_puppet_conf_dir}/hostautotag.conf"
+    $hostmetadata_config_file           = "${oneagent_puppet_conf_dir}/hostcustomproperties.conf"
+    $hostname_config_file               = "${oneagent_puppet_conf_dir}/hostname.conf"
+    $oneagent_infraonly_config_file     = "${oneagent_puppet_conf_dir}/infraonly.conf"
+    $oneagent_networkzone_config_file   = "${oneagent_puppet_conf_dir}/networkzone.conf"
+  }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,18 +2,19 @@
 #   Manages the OneAgent service
 #
 class dynatraceoneagent::service {
+  $manage_service = $dynatraceoneagent::manage_service
+  $service_name   = $dynatraceoneagent::service_name
+  $require_value  = $dynatraceoneagent::params::require_value
+  $service_state  = $dynatraceoneagent::service_state
+  $package_state  = $dynatraceoneagent::package_state
 
-  $service_name             = $dynatraceoneagent::service_name
-  $require_value            = $dynatraceoneagent::params::require_value
-  $service_state            = $dynatraceoneagent::service_state
-  $package_state            = $dynatraceoneagent::package_state
-
+  if $manage_service {
     service{ $service_name:
-        ensure     => $service_state,
-        enable     => true,
-        hasstatus  => true,
-        hasrestart => true,
-        require    => $require_value,
+      ensure     => $service_state,
+      enable     => true,
+      hasstatus  => true,
+      hasrestart => true,
+      require    => $require_value,
     }
-
+  }
 }

--- a/manifests/uninstall.pp
+++ b/manifests/uninstall.pp
@@ -3,9 +3,9 @@
 #
 class dynatraceoneagent::uninstall {
 
-  $provider                            = $dynatraceoneagent::provider
-  $install_dir                         = $dynatraceoneagent::install_dir
-  $created_dir                         = $dynatraceoneagent::created_dir
+  $provider    = $dynatraceoneagent::provider
+  $install_dir = $dynatraceoneagent::install_dir
+  $created_dir = $dynatraceoneagent::created_dir
 
   $created_dir_exists = find_file($created_dir)
 


### PR DESCRIPTION
Workaround to address/cater for https://github.com/Dynatrace/Dynatrace-OneAgent-Puppet/issues/49

add `manage_service` parameter to allow service to be unmanaged (eg: on AIX if no SRC subsystem or rc scripts are in place)