### PR TITLE
Add puppet-archive as a requirement.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -92,6 +92,10 @@
       "name": "puppet",
       "version_requirement": ">= 4.10.0 < 7.0.0"
     }
+    {
+      "name": "puppet-archive",
+      "version_requirement": ">= 4.0.0 < 7.0.0"
+    }
   ],
   "pdk-version": "1.18.0",
   "template-url": "pdk-default#1.18.0",


### PR DESCRIPTION
Dynatrace module requires "archive" class but it's not in metadata.json.

I did my best guess at the minimum version requirement of puppet-archive.  4.0.0 works as well as the latest version (as of this pull request).